### PR TITLE
feat: enhance control-marker-hand-distinction, add cm_enabled-flag

### DIFF
--- a/src/main/java/de/dhbw/Main.java
+++ b/src/main/java/de/dhbw/Main.java
@@ -101,6 +101,10 @@ public class Main {
                                 // TODO find out how to reset to the prev value
                                 videoIn.setInputDevice(0);
                             }
+                            break;
+                        case TOGGLE_CM:
+                            shapeProcessor.setEnableControlMarker((boolean) setting.getValue());
+                            break;
                         case null, default:
                             break;
                     }

--- a/src/main/java/de/dhbw/Statics.java
+++ b/src/main/java/de/dhbw/Statics.java
@@ -23,6 +23,7 @@ public class Statics {
     public final static int MIN_TEMPO = 40;
     public final static int DEFAULT_VELOCITY = 80;
     public final static int MAX_VELOCITY = 127;
+    public final static int MIN_VELOCITY = 0;
 
     //MIDI
     public final static String DEFAULT_MIDI_DEVICE = "Gervill";

--- a/src/main/java/de/dhbw/Statics.java
+++ b/src/main/java/de/dhbw/Statics.java
@@ -28,4 +28,5 @@ public class Statics {
     public final static String DEFAULT_MIDI_DEVICE = "Gervill";
     // TODO find clicking sound
     public final static int METRONOME_SOUND = 45;
+    public final static int METRONOME_UP_SOUND = 47;
 }

--- a/src/main/java/de/dhbw/communication/SettingType.java
+++ b/src/main/java/de/dhbw/communication/SettingType.java
@@ -10,5 +10,6 @@ public enum SettingType {
     GUI_TEMPO,
     CM_TEMPO,
     CAMERA,
-    STOP_LOOP
+    STOP_LOOP,
+    TOGGLE_CM
 }

--- a/src/main/java/de/dhbw/music/MidiAdapter.java
+++ b/src/main/java/de/dhbw/music/MidiAdapter.java
@@ -24,7 +24,12 @@ public class MidiAdapter {
             midiBatchMessage.clearMessages();
             lastInterval = posInBeat;
             if(metronomeActive && posInBeat % 2 == 0){
-                midiBatchMessage.addMidiMessage(Statics.METRONOME_SOUND, velocity, -1);
+                if(posInBeat == 0 || posInBeat == Statics.NO_BEATS/2){
+                    midiBatchMessage.addMidiMessage(Statics.METRONOME_UP_SOUND, velocity, -1);
+                }
+                else{
+                    midiBatchMessage.addMidiMessage(Statics.METRONOME_SOUND, velocity, -1);
+                }
             }
             for(int note = 0; note < soundMatrix[posInBeat].length; note++){
                 if (soundMatrix[posInBeat][note]){

--- a/src/main/java/de/dhbw/ui/VideoScene.java
+++ b/src/main/java/de/dhbw/ui/VideoScene.java
@@ -7,9 +7,7 @@ import de.dhbw.communication.UIMessage;
 import de.dhbw.video.shape.Shape;
 import javafx.beans.value.ChangeListener;
 import javafx.fxml.FXML;
-import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.TextField;
-import javafx.scene.control.TextFormatter;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
@@ -65,6 +63,8 @@ public class VideoScene {
     private ChoiceBox<String> midi_choicebox;
     @FXML
     private ChoiceBox<String> camera_choicebox;
+    @FXML
+    private Button cm_button;
 
     @FXML
     private FlowPane music_tab;
@@ -81,6 +81,7 @@ public class VideoScene {
     private boolean metronomeRunning = false;
     private boolean mute = false;
     private boolean settingsVisible = false;
+    private boolean controlMarkersEnabled = true;
     private boolean musicPaneVisible = false;
     private double aspectRatioFrame;
     private double frameWidth = -1;
@@ -346,6 +347,15 @@ public class VideoScene {
         camera_choicebox.setValue( cameras.contains(currentCam) ? currentCam : "0" );
         Setting<Boolean> restart = new Setting<>(SettingType.STOP_LOOP, false);
         EventQueues.toController.add(restart);
+    }
+
+    @FXML
+    private void toggleControlMarkers() {
+        controlMarkersEnabled = !controlMarkersEnabled;
+        Setting<Boolean> setting = new Setting<>(SettingType.TOGGLE_CM, controlMarkersEnabled);
+        EventQueues.toController.add(setting);
+
+        cm_button.setText(controlMarkersEnabled ? "Disable" : "Enable");
     }
 
     @FXML

--- a/src/main/java/de/dhbw/video/MarkerRecognizer.java
+++ b/src/main/java/de/dhbw/video/MarkerRecognizer.java
@@ -72,7 +72,6 @@ public class MarkerRecognizer {
                 form = ShapeForm.CIRCLE;
             }
             else {
-                //System.out.println("skipping shape because of edge mismatch");
                 continue;
             }
             idxMax = 0;
@@ -95,33 +94,7 @@ public class MarkerRecognizer {
             };
             shapes.add(new Shape(contour, form, Shape.calcPositionFromMoments(Imgproc.moments(contour)), color));
         }
-//        detectColours();
     }
-
-//    private void detectColours(){
-//        double[] vals;
-//        int idxMax; double prevMax;
-//        for(Shape s:shapes){
-//            idxMax = 0;
-//            prevMax = 0;
-//            Mat mask = new Mat(frame.size(), CvType.CV_8UC1, Scalar.all(0));
-//            Imgproc.drawContours(mask, List.of(s.getContour()), -1, new Scalar(255), -1);
-//            vals = Core.mean(frame, mask).val;
-//            mask.release();
-//            for (int idx = 0; idx < 3; idx++) {
-//                if(vals[idx] > prevMax){
-//                    prevMax = vals[idx];
-//                    idxMax = idx;
-//                }
-//            }
-//            switch (idxMax){
-//                case 0: s.setColor(ShapeColor.BLUE); break;
-//                case 1: s.setColor(ShapeColor.GREEN); break;
-//                case 2: s.setColor(ShapeColor.RED); break;
-//                default:s.setColor(ShapeColor.UNDEFINED); break;
-//            }
-//        }
-//    }
 
     private void findContours(){
         Imgproc.cvtColor(frame, gray, Imgproc.COLOR_BGR2GRAY);

--- a/src/main/java/de/dhbw/video/ShapeProcessor.java
+++ b/src/main/java/de/dhbw/video/ShapeProcessor.java
@@ -31,6 +31,9 @@ public class ShapeProcessor {
     private boolean[][] soundMatrix = new boolean[NO_BEATS][NO_NOTES];
     @Setter
     private double lastVelocity = 0, lastTempo = 0;
+    @Setter
+    private boolean enableControlMarker = true;
+    private final int[] cmRegocCount = new int[2];
     public ShapeProcessor(){
         playFieldBoundaries = new Mat[4];
         for(int i = 0; i < 4; i++) {
@@ -49,7 +52,7 @@ public class ShapeProcessor {
         if(playfieldInfo[4] == 1){
             generateSoundMatrix();
         }
-        detectControlMarkers();
+        if(enableControlMarker) detectControlMarkers();
     }
 
 
@@ -106,17 +109,31 @@ public class ShapeProcessor {
         if(rect.size() == 1 && ( rect.get(0).pos[0] < playfieldInfo[0] || rect.get(0).pos[0] > playfieldInfo[0] + playfieldInfo[2])){
             double nextVelocity = (double) rect.get(0).pos[1]/480;
             if(Math.abs(nextVelocity - lastVelocity) > 0.05){
-                System.out.println("Changing velocity with cm: " + rect.size() + ", setting to " + nextVelocity);
-                lastVelocity = nextVelocity;
-                EventQueues.toController.offer(new Setting<>(SettingType.CM_VELOCITY, lastVelocity));
+                cmRegocCount[0]++;
+                if(cmRegocCount[0] == 15) {
+                    System.out.println("Changing velocity with cm: " + rect.size() + ", setting to " + nextVelocity);
+                    lastVelocity = nextVelocity;
+                    EventQueues.toController.offer(new Setting<>(SettingType.CM_VELOCITY, lastVelocity));
+                    cmRegocCount[0] = 0;
+                }
+            }
+            else{
+                cmRegocCount[0] = 0;
             }
         }
         if(triangles.size() == 1 && (triangles.get(0).pos[0] < playfieldInfo[0] || triangles.get(0).pos[0] > playfieldInfo[0] + playfieldInfo[2])){
             double nextTempo = (double) triangles.get(0).pos[1]/480;
             if(Math.abs(nextTempo - lastTempo) > 0.05){
-                System.out.println("Changing tempo with cm: " + triangles.size() + ", setting to " + nextTempo);
-                lastTempo = nextTempo;
-                EventQueues.toController.offer(new Setting<>(SettingType.CM_TEMPO, lastTempo));
+                cmRegocCount[1]++;
+                if(cmRegocCount[1] == 15) {
+                    System.out.println("Changing tempo with cm: " + triangles.size() + ", setting to " + nextTempo);
+                    lastTempo = nextTempo;
+                    EventQueues.toController.offer(new Setting<>(SettingType.CM_TEMPO, lastTempo));
+                    cmRegocCount[1] = 0;
+                }
+            }
+            else{
+                cmRegocCount[1] = 0;
             }
         }
 

--- a/src/main/resources/VideoScene.fxml
+++ b/src/main/resources/VideoScene.fxml
@@ -130,6 +130,8 @@
                 <Label styleClass="heading" text="Music Settings:"/>
                 <Label styleClass="setting_label" text="Tempo:"/>
                 <TextField fx:id="tempo_field" styleClass="textfield" prefWidth="80.0" onAction="#sendTempoSetting"/>
+                <Label styleClass="setting_label" text="Velocity:"/>
+                <TextField fx:id="velocity_field" styleClass="textfield" prefWidth="80.0" onAction="#sendVelocitySetting"/>
             </FlowPane>
 
         </GridPane>

--- a/src/main/resources/VideoScene.fxml
+++ b/src/main/resources/VideoScene.fxml
@@ -82,16 +82,30 @@
             >
                 <Label styleClass="heading" text="Settings:"/>
                 <Label styleClass="setting_label" text="MIDI Output:" />
-                <ChoiceBox fx:id="midi_choicebox" styleClass="choice-box" prefWidth="100.0" onAction="#sendMidiSetting" value="Gervill"/>
+                <ChoiceBox fx:id="midi_choicebox" styleClass="choice-box" prefWidth="100.0" onAction="#sendMidiSetting" value="Gervill">
+                    <cursor>
+                        <Cursor fx:constant="HAND" />
+                    </cursor>
+                </ChoiceBox>
                 <Label styleClass="setting_label" text="Video Input Device:" />
                 <HBox>
-                    <ChoiceBox fx:id="camera_choicebox" styleClass="choice-box" prefWidth="50.0" onMouseClicked="#sendCameraSetting" value="0"/>
+                    <ChoiceBox fx:id="camera_choicebox" styleClass="choice-box" prefWidth="50.0" onMouseClicked="#sendCameraSetting" value="0">
+                        <cursor>
+                            <Cursor fx:constant="HAND" />
+                        </cursor>
+                    </ChoiceBox>
                     <Button styleClass="button" onAction="#stopVideoProcessing" text="Scan for cameras">
                         <cursor>
                             <Cursor fx:constant="HAND" />
                         </cursor>
                     </Button>
                 </HBox>
+                <Label styleClass="setting_label" text="Detect ControlMarkers:" />
+                <Button fx:id="cm_button" styleClass="button" onAction="#toggleControlMarkers" text="Disable">
+                    <cursor>
+                        <Cursor fx:constant="HAND" />
+                    </cursor>
+                </Button>
             </FlowPane>
 
             <FlowPane fx:id="music_tab" alignment="CENTER" nodeOrientation="LEFT_TO_RIGHT" prefHeight="40.0"


### PR DESCRIPTION
enhances controlMarker recognition by only reacting to controlMarkers that appear in 15 consecutive frames, 
also adds a Message (and corresponding action) that disables control-marker recognition completely